### PR TITLE
Update data format and python 3 support for trace converter

### DIFF
--- a/Trace.py
+++ b/Trace.py
@@ -102,15 +102,15 @@ class TraceSet():
         return struct.unpack("f",self._handle.read(4))[0];
 
     def _writeUINT8(self, val):
-        #print "UINT8: %02x"%(val&0xFF)
+        #print("UINT8: %02x"%(val&0xFF))
         return self._handle.write(struct.pack("B",(val&0xFF)));
 
     def _writeUINT16(self, val):
-        #print "UINT16: %04x"%(val&0xFFFF)
+        #print("UINT16: %04x"%(val&0xFFFF))
         return self._handle.write(struct.pack("H",(val&0xFFFF)));
 
     def _writeUINT32(self, val):
-        #print "UINT32: %08x"%(val&0xFFFFFFFF)
+        #print("UINT32: %08x"%(val&0xFFFFFFFF))
         return self._handle.write(struct.pack("I",(val&0xFFFFFFFF)));
 
     def _writeTitleSpace(self, val):


### PR DESCRIPTION
- Updated the Trace code to support python3 by adding the parenthesis on the print function.
- The data format expected was 128 bits, but now the script supports other inputs size.
- The output is still words of 64 bits, but it should be easy to support other data formats.